### PR TITLE
1.16.5 support

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -25,6 +25,6 @@
   "depends": {
     "fabricloader": ">=0.10.3+build.211",
     "fabric": "*",
-    "minecraft": "1.16.4"
+    "minecraft": "1.16.5"
   }
 }


### PR DESCRIPTION
This pull request will add 1.16.5 client support. All that was needed was to change "1.16.4" in `/src/main/resources/fabric.mod.json` to "1.16.5".

This is my first pull request, apologies if I've done it wrong.